### PR TITLE
Adding the possibility to get the html without write the body

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,7 +60,7 @@ app.listen(2333);
 
 * root: view root directory
 
-* wResponse: default(true) auto write body html response
+* writeBody: default(true) auto write body html response
 
 
 #### Others

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ var defaultSettings = {
   root: 'views',
   cache: 'memory',
   ext:  'html',
-  wResponse:true
+  writeBody:true
   /*
   locals: {},
   filters: {}.
@@ -105,7 +105,7 @@ function renderer(app, settings) {
     var html = yield renderFile(view, opts);
     /* jshint validthis:true */
 
-    if (settings.wResponse === true) {
+    if (settings.writeBody === true) {
       this.type = 'html';
       this.body = html;
     }

--- a/test/index.js
+++ b/test/index.js
@@ -51,7 +51,7 @@ describe('koa-swig', function () {
         .expect(200, done);
     });
 
-    it('should not return response with wResponse = false', function (done) {
+    it('should not return response with writeBody = false', function (done) {
       var app = koa();
       render(app, {
         root: path.join(__dirname, '../example'),
@@ -59,7 +59,7 @@ describe('koa-swig', function () {
         filters: {
           format: function (v) { return v.toUpperCase(); }
         },
-        wResponse:false
+        writeBody:false
       });
       app.use(function *() {
         yield this.render('basic', {
@@ -72,7 +72,7 @@ describe('koa-swig', function () {
         .expect(404, done);
     });
 
-    it('should return response with wResponse = false and write the body manually', function (done) {
+    it('should return response with writeBody = false and write the body manually', function (done) {
       var app = koa();
       render(app, {
         root: path.join(__dirname, '../example'),
@@ -80,7 +80,7 @@ describe('koa-swig', function () {
         filters: {
           format: function (v) { return v.toUpperCase(); }
         },
-        wResponse:false
+        writeBody:false
       });
       app.use(function *() {
         var html = yield this.render('basic', {


### PR DESCRIPTION
Some times you only need the html for different purposes. For example, if you want to get the html to send an email, or you want to write an ajax response with extra information.

For that reason I added an attribute configuration to add the possibility to disable the auto write response . Additionally the render function, always return the html.

```
require('koa-swig')(app,{
    root: path.join(__dirname, 'views'),
    autoescape: true,
    cache: 'memory', // disable, set to false
    ext: 'html',
    wResponse :false,
});
```

Geting the html....

```
var html = yield this.render('site/index',{title:'chr-koabase'});
this.type = 'html';
this.body = html;
```
