### PR TITLE
support varControls option

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,12 +63,11 @@ function renderer(app, settings) {
   var root = settings.root;
   var locals = settings.locals;
   var cache = settings.cache;
-  var varControls = settings.varControls;
   swig.setDefaults({
     autoescape: settings.autoescape,
     cache: cache,
     locals: locals,
-    varControls: varControls
+    varControls: settings.varControls
   });
 
   // swig custom filters


### PR DESCRIPTION
varControls eliminates the needs of {% raw %} ... {% endraw %} when open/close control for variables conflicts.
