### PR TITLE
Added support for this.locals

### DIFF
--- a/example/locals.html
+++ b/example/locals.html
@@ -1,0 +1,5 @@
+{% if hasLocals %}
+Request has locals
+{% else %}
+Request doesnt have locals
+{% endif %}

--- a/index.js
+++ b/index.js
@@ -103,7 +103,9 @@ function renderer(settings) {
     });
 
     // merge settings.locals
-    mixin(opts, locals);
+    if(this.locals){
+      mixin(opts, this.locals);
+    }
 
     // merge options
     mixin(opts, options || {});

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "istanbul-harmony": "*",
     "koa": "^0.x",
     "koa-flash": "^1.x",
+    "koa-locals": "^0.3.0",
     "koa-session": "^3.x",
     "mocha": "^2.x",
     "should": "^5.x",

--- a/test/index.js
+++ b/test/index.js
@@ -216,6 +216,26 @@ describe('koa-swig', function() {
     });
   });
 
+  describe('locals', function() {
+    var app = koa();
+    var locals = require('koa-locals');
+
+    locals(app, {hasLocals:true});
+    app.context.render = render({
+      root: path.join(__dirname, '../example')
+    });
+    app.use(function*() {
+      this.locals.hasLocals = true;
+      yield this.render('locals');
+    });
+    it('should success', function(done) {
+      request(app.listen())
+        .get('/')
+        .expect(/Request has locals/)
+        .expect(200, done);
+    });
+  });  
+
   describe('koa state', function() {
     var app = koa();
     app.context.render = render({


### PR DESCRIPTION
The content of this.locals is not been passed to the template. 

Also, I think that `mixin(opts, locals);` doesn't do anything with koa-locals since locals is a function and `utils-merge` merges objects, so I removed `mixin(opts, locals);`.